### PR TITLE
Add killbind check for suicide hints

### DIFF
--- a/lua/autorun/client/cl_tloudeath.lua
+++ b/lua/autorun/client/cl_tloudeath.lua
@@ -118,6 +118,10 @@ local hinttable = {
 				"Contact your local killbind prevention hotline. We're here to help.",
 				LocalPlayer():Nick().." took the easy way out."
 			}
+			local killbind = input.LookupBinding("kill", true)
+			if killbind then
+				table.insert(suicidehints, "Bind "..killbind.." to kill, huh? Not what I'd have picked.",)	
+			end
 			return suicidehints[math.random(#suicidehints)]
 		else
 			return hinttablegeneric[math.random(#hinttablegeneric)]


### PR DESCRIPTION
Only adds the killbind hint if there is a valid keybind.
Let me know if the check doesn't work, as input.LookupBinding is one of those strange functions that may return "no value" instead of "nil", which may cause problems.